### PR TITLE
Cache columns, make import process and docs more robust

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,10 +69,11 @@ dependencies {
     
     //GraphQL
     //compile "com.graphql-java:graphql-java-annotations:0.11.0"
-    compile ('com.embedler.moon.graphql.boot.starter:graphql-spring-boot-starter:2.0') {
-        exclude group: 'com.fasterxml.jackson.core'
-        exclude group: 'org.springframework'
-    }
+    //compile ('com.embedler.moon.graphql.boot.starter:graphql-spring-boot-starter:2.0') {
+    //    exclude group: 'com.fasterxml.jackson.core'
+    //    exclude group: 'org.springframework'
+    //}
+    compile 'com.graphql-java:graphql-java:2.0.0'
     compile 'com.embedler.moon.graphql.boot.starter:graphiql-spring-boot-starter:2.0.0'
     
     //DB - uncomment lines to use other DB implementations.

--- a/src/main/kotlin/ticketpile/service/BackgroundTasks.kt
+++ b/src/main/kotlin/ticketpile/service/BackgroundTasks.kt
@@ -1,0 +1,52 @@
+package ticketpile.service
+
+import org.springframework.boot.CommandLineRunner
+import org.springframework.core.Ordered
+import org.springframework.stereotype.Component
+import ticketpile.service.advance.AdvanceManager
+import ticketpile.service.advance.bookingQueueSync
+import ticketpile.service.advance.individualBookingSync
+import java.io.PrintWriter
+import java.io.StringWriter
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+/**
+ * Background tasks meant to launch after the application is started and DB
+ * is connected.
+ * 
+ * Created by jonlatane on 10/14/16.
+ */
+fun wrapTask(task: () -> Unit, taskName: String) : () -> Unit {
+    return {
+        try {
+            task()
+        } catch(t: Throwable) {
+            val sw = StringWriter()
+            t.printStackTrace(PrintWriter(sw))
+            println("$taskName error: $sw")
+        }
+    }
+}
+
+@Component
+open class BackgroundJobs() : CommandLineRunner, Ordered {
+    override fun run(vararg args : String) {
+        val scheduler = Executors.newScheduledThreadPool(13)
+        scheduler.scheduleAtFixedRate(
+                wrapTask(bookingQueueSync, "Booking Queue Sync"),
+                0, AdvanceManager.syncPeriodSeconds, TimeUnit.SECONDS
+        )
+        // Schedule multiple tasks for booking sync
+        for(offset in 1..3) {
+            scheduler.scheduleAtFixedRate(
+                    wrapTask(individualBookingSync, "Individual Booking Sync"),
+                    0, 10, TimeUnit.MILLISECONDS
+            )
+        }
+    }
+
+    override fun getOrder(): Int {
+        return 2
+    }
+}

--- a/src/main/kotlin/ticketpile/service/TicketPile.kt
+++ b/src/main/kotlin/ticketpile/service/TicketPile.kt
@@ -48,6 +48,8 @@ open class TicketPile {
             SpringApplication.run(TicketPile::class.java, *args)
         }
     }
+    @Autowired
+    lateinit var ssoConfig : AdvanceSSOConfig
     
     @Bean
     open fun tpApi() : Docket {
@@ -61,8 +63,52 @@ open class TicketPile {
                         "It also logs errors when totals from imported data fail to match those on the Advance " +
                         "reservation." + 
                         "<p/>" +
-                        "TicketPile's <a href=\"/graphiql.html\">GraphQL API</a> supports SSO with Advance and " +
-                        "allows for highly efficient querying of Advance data."
+                        "TicketPile's <a href=\"/graphiql.html\">GraphQL API</a> should be a useful tool for " +
+                        "Advance FE developers." + 
+                        "<p/>" + 
+                        "<h2>SSO Configuration</h2>" +
+                        "This TicketPile instance is pointed at <a href=\"${ssoConfig.host}\">" +
+                        "${ssoConfig.host}</a>." +
+                        "<p/>" + 
+                        "TicketPile's GraphQL API supports SSO with any Advance instance.  Just provide " +
+                        "it with a Bearer token that's valid on the Advance instance, and you can access " +
+                        "all the locations (and only the locations) that Advance says that user should have " +
+                        "access to. To change the SSO host, update <span style=\"font-family:monospace;\">" +
+                        "advance_sso.properties</span> and restart the server." +
+                        "<p/>" +
+                        "<h2>Administrator Operation</h2>" +
+                        "<ol style=\"list-style-type: decimal;\">" +
+                        "<li>Get your API token from the console where this server was started, " +
+                        "and paste it in the box to the upper-right corner of the screen." +
+                        "<ul>" +
+                        "<li>Because of Swagger limitations, the following links will unset " +
+                        "your admin token. So keep it handy :)</li>" +
+                        "<li>In the GraphQL API, admin tokens are allowed to access all " +
+                        "locations that have synchronization set up.</li>" + 
+                        "</ul>" +
+                        "</li>" +
+                        "<li><a href=\"/swagger-ui.html?#!/advance-sync-controller/addLocationUsingPOST\">" +
+                        "Set up synchronization with an Advance server</a>." +
+                        "<ul>" +
+                        "<li>TicketPile syncs data <i>per location</i>. So if we hit performance " +
+                        "limitations, it's easy to spin up more instances for new customers.</li>" +
+                        "<li>Some sample location configurations:" +
+                        "<table>" +
+                        "<tr><td><b>User</b></td><td><b>Password</b></td><td><b>LocationID</b></td></tr>" +
+                        "<tr><td>advance-dev@zozi.com</td><td>advance-dev@zozi.com</td><td>14948</td></tr>" +
+                        "<tr><td>info@experiencetheride.com</td><td>(varies)</td><td>34100</td></tr>" +
+                        "</table>" +
+                        "</li>" + 
+                        "</ul>" +
+                        "</li>" +
+                        "<li><a href=\"swagger-ui.html??#!/advance-sync-controller/getAllQueuesUsingGET\">" +
+                        "Check the status of your indexed locations.</a> Data is up-to-date when"  +
+                        "the queue size is 0.  These queues also provide handy Advance auth tokens " +
+                        "that you can use in the <a href=\"/graphiql.html\">GraphQL API</a>.</li>" +
+                        "<li>Check for <a href=\"swagger-ui.html???#!/advance-sync-controller/getErrorsUsingGET\">" +
+                        "errors</a> and <a href=\"swagger-ui.html????#!/advance-sync-controller/getWarningsUsingGET\">" +
+                        "warnings</a> in your imported data.</li>" +
+                        "</ol>"
                 )
                 .version("0.1")
                 .build())

--- a/src/main/kotlin/ticketpile/service/TicketPile.kt
+++ b/src/main/kotlin/ticketpile/service/TicketPile.kt
@@ -64,9 +64,10 @@ open class TicketPile {
                 .title("TicketPile API")
                 .description("TicketPile is an ETL and integration testing layer for Advance. " +
                         "It transforms JSON data from the Advance API into a normalized relational database. " +
-                        "<p>" + 
-                        "It logs inconsistencies it finds in data it retrieves from Advance. It will also provides errors " +
-                        "when totals from imported data fail to match those on the Advance reservation.")
+                        "<p/>" + 
+                        "TicketPile logs warnings of inconsistencies it finds in data it retrieves from Advance. " +
+                        "It also logs errors when totals from imported data fail to match those on the Advance " +
+                        "reservation.")
                 .version("0.1")
                 .build())
         .securitySchemes(listOf(ApiKey("mykey", apiTokenHeader, "header")))

--- a/src/main/kotlin/ticketpile/service/TicketPile.kt
+++ b/src/main/kotlin/ticketpile/service/TicketPile.kt
@@ -1,9 +1,5 @@
 package ticketpile.service
 
-import com.oembedler.moon.graphql.boot.EnableGraphQLServer
-import com.oembedler.moon.graphql.boot.GraphQLSchemaLocator
-import com.oembedler.moon.graphql.engine.GraphQLSchemaConfig
-import com.oembedler.moon.graphql.engine.GraphQLSchemaHolder
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
 import org.jetbrains.exposed.sql.Database
@@ -34,13 +30,11 @@ import ticketpile.service.advance.bookingQueueSync
 import ticketpile.service.advance.individualBookingSync
 import ticketpile.service.advance.initializeSynchronization
 import ticketpile.service.database.initializeModel
-import ticketpile.service.graphql.TicketPileGraphQLSchema
 import ticketpile.service.security.initializeSecurity
 import ticketpile.service.springconfig.apiTokenHeader
 import ticketpile.service.util.transaction
 import java.io.PrintWriter
 import java.io.StringWriter
-import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import javax.sql.DataSource
@@ -100,7 +94,7 @@ open class TicketPile {
             null
         )
     }
-
+/*
     @Bean
     //@ConditionalOnMissingBean
     //@Throws(ClassNotFoundException::class)
@@ -123,6 +117,7 @@ open class TicketPile {
         }*/
         return GraphQLSchemaLocator(graphQLSchemaHolders)
     }
+    */
 }
 
 @Component

--- a/src/main/kotlin/ticketpile/service/advance/AdvanceApi.kt
+++ b/src/main/kotlin/ticketpile/service/advance/AdvanceApi.kt
@@ -22,11 +22,19 @@ class AdvanceAuthResponse() {
 }
 
 class AdvanceUserRespose() {
-    lateinit var user : AdvanceUser
+    var user : AdvanceUser? = null
 }
 
 class AdvanceUser() {
     lateinit var emailAddress : String
+    lateinit var merchants : List<AdvanceMerchant>
+}
+
+class AdvanceMerchant() {
+    lateinit var merchantID : String
+    val locationId :Int get() {
+        return merchantID.toInt()
+    }
 }
 
 class AdvanceModifiedBookingsResponse() {

--- a/src/main/kotlin/ticketpile/service/advance/AdvanceApi.kt
+++ b/src/main/kotlin/ticketpile/service/advance/AdvanceApi.kt
@@ -53,12 +53,12 @@ class AdvanceReservation() {
     var bookingID  = -1    
     var bookingItems = emptyList<AdvanceBookingItem>()         
     var bookingStatus = ""
-    var channelCode = ""    
+    var channelCode : String? = null    
 	var currencyCode = ""    
 	var customer = AdvanceCustomer()    
 	var lineTotals = emptyList<AdvanceLineTotal>()    
 	var merchantID = -1
-	var officeNotes = ""    
+	var officeNotes : String? = null
 	var orderTakerID = -1    
 	var payments = emptyList<AdvancePayment>()    
 	var pricing = AdvancePricing()    
@@ -86,7 +86,7 @@ class AdvanceBookingItem() {
     var availabilityID = -1
     var bookingItemID = -1
     var noPersons = emptyList<Int>()
-    var productId = -1
+    var productID = -1
 	var addonSelections = emptyList<AdvanceAddOnSelection>()
     var ticketCodes = emptyList<AdvanceTicketCode>()
     var lineTotals = emptyList<AdvanceLineTotal>()
@@ -128,6 +128,7 @@ class AdvancePayment() {
 class AdvancePricing() {
     var baseAmount = BigZero
     var totalAmount = BigZero
+    var taxAmount : BigDecimal? = BigZero
     var priceAdjustments = emptyList<AdvancePriceAdjustment>()
 }
 
@@ -173,20 +174,20 @@ class AdvanceProductsReponse() {
 class AdvanceProduct() {
     var productID = -1
     var name = ""
-    var shortDescription = ""
+    var shortDescription :String ?= null
 }
 
 class AdvancePromotionResponse() {
     var promotion = AdvancePromotion()
 }
 
-class AdvancePromotion() {
-    var promotionCode = ""
-    var description : String? = ""
-    var calcbasis = "perperson"
-    var associations = emptyList<AdvancePromotionAssociation>()
-    var personCategories = emptyList<AdvancePromotionPersonCategory>()
-}
+class AdvancePromotion(
+        var promotionCode : String = "",
+        var description : String? = "",
+        var calcbasis : String = "perperson",
+        var associations : List<AdvancePromotionAssociation> = emptyList<AdvancePromotionAssociation>(),
+        var personCategories : List<AdvancePromotionPersonCategory> = emptyList<AdvancePromotionPersonCategory>()
+)
 
 class AdvanceAddOnResponse() {
     var addon = AdvanceAddOn()

--- a/src/main/kotlin/ticketpile/service/advance/AdvanceApi.kt
+++ b/src/main/kotlin/ticketpile/service/advance/AdvanceApi.kt
@@ -2,6 +2,7 @@ package ticketpile.service.advance
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import org.joda.time.DateTime
+import ticketpile.service.util.BigZero
 import java.math.BigDecimal
 
 /**
@@ -97,7 +98,7 @@ class AdvanceLineTotal() {
     var type = -1
     var label = ""
     var quantity = -1
-    var price = BigDecimal.ZERO
+    var price = BigZero
     var unitPrice : BigDecimal? = null
 }
 
@@ -117,13 +118,13 @@ class AdvancePayment() {
 }
 
 class AdvancePricing() {
-    var baseAmount = BigDecimal.ZERO
-    var totalAmount = BigDecimal.ZERO
+    var baseAmount = BigZero
+    var totalAmount = BigZero
     var priceAdjustments = emptyList<AdvancePriceAdjustment>()
 }
 
 class AdvancePriceAdjustment(
-        var amount : BigDecimal = BigDecimal.ZERO,
+        var amount : BigDecimal = BigZero,
         var label : String = "",
         var promotionID : Int? = null,
         var type : Int = 0

--- a/src/main/kotlin/ticketpile/service/advance/AdvanceBookingManager.kt
+++ b/src/main/kotlin/ticketpile/service/advance/AdvanceBookingManager.kt
@@ -1,8 +1,11 @@
 package ticketpile.service.advance
 
 import org.jetbrains.exposed.sql.and
-import ticketpile.service.database.*
+import ticketpile.service.database.AddOns
+import ticketpile.service.database.Bookings
+import ticketpile.service.database.PersonCategories
 import ticketpile.service.model.*
+import ticketpile.service.model.transformation.TicketAdjustmentTransform
 import ticketpile.service.util.BigZero
 import ticketpile.service.util.decimalScale
 import ticketpile.service.util.flushEntityCache
@@ -49,6 +52,7 @@ class AdvanceBookingManager(host: String, authorizationKey: String, locationId: 
             location = locationId
             customer = bookingCustomer
             status = reservation.bookingStatus
+            taxAmount = reservation.pricing.taxAmount ?: BigZero
         }
 
         importBookingItems(booking, reservation)
@@ -100,7 +104,7 @@ class AdvanceBookingManager(host: String, authorizationKey: String, locationId: 
         // Advance tries to break down discounts on its own.
         // Undo that work, TicketPile is designed to do this better.
         val groupedDiscounts = reservation.pricing.priceAdjustments
-                .filter { it.type == 1500 }.groupBy { it.promotionID }.values.map {
+                .filter { it.type == 1500 }.groupBy { it.promotionID to it.label }.values.map {
             it.reduce { priceAdjustment1, priceAdjustment2 ->
                 AdvanceSyncError.new {
                     errorType = SyncErrorType.extraDiscountCodes
@@ -117,14 +121,10 @@ class AdvanceBookingManager(host: String, authorizationKey: String, locationId: 
         }
 
         groupedDiscounts.forEach{
-            aDiscount ->
-            val discountUsed = Discount.find {
-                (Discounts.externalSource eq source) and
-                        (Discounts.externalId eq aDiscount.promotionID)
-            }.first()
+            val discountUsed = getDiscount(it)
             BookingDiscount.new {
                 booking = targetBooking
-                amount = aDiscount.amount
+                amount = it.amount
                 discount = discountUsed
             }
         }
@@ -139,15 +139,14 @@ class AdvanceBookingManager(host: String, authorizationKey: String, locationId: 
             advanceAddOnSelection.options.filter {
                 it.label != null
             }.forEach {
-                option ->
                 val theAddOn = AddOn.find {
                     (AddOns.externalSource eq source) and
                             (AddOns.externalId eq advanceAddOnSelection.addonID)
                 }.first()
                 BookingAddOn.new {
                     addOn = theAddOn
-                    selection = option.label!!
-                    amount = theAddOn.basis.priceMethod(option.price ?: BigZero, targetBooking)
+                    selection = it.label!!
+                    amount = theAddOn.basis.priceMethod(it.price ?: BigZero, targetBooking)
                     subject = targetBooking
                 }
             }
@@ -191,20 +190,16 @@ class AdvanceBookingManager(host: String, authorizationKey: String, locationId: 
             reservation: AdvanceReservation
     ) {
         reservation.bookingItems.forEach {
-            aBookingItem: AdvanceBookingItem ->
-            val targetEvent = Event.find {
-                (Events.externalSource eq source) and
-                        (Events.externalId eq aBookingItem.availabilityID)
-            }.first()
+            val targetEvent = findAvailabilityFor(it)
             val bookingItem = BookingItem.new {
                 booking = targetBooking
                 event = targetEvent
                 externalSource = source
-                externalId = aBookingItem.bookingItemID
+                externalId = it.bookingItemID
             }
-            importTickets(aBookingItem, bookingItem)
             flushEntityCache()
-            importBookingItemAddOns(aBookingItem, bookingItem)
+            importTickets(it, bookingItem)
+            importBookingItemAddOns(it, bookingItem)
         }
     }
 
@@ -242,79 +237,112 @@ class AdvanceBookingManager(host: String, authorizationKey: String, locationId: 
             aBookingItem: AdvanceBookingItem,
             targetBookingItem: BookingItem
     ) {
-        val ticketMetadata = generatePersonCategoryTicketData(aBookingItem)
-        val erroredPersonCategories = mutableSetOf<PersonCategory>()
+        val ticketMetadata = generatePersonCategoryTicketData(aBookingItem, targetBookingItem)
+        val recycledTicketCodes = mutableListOf<AdvanceTicketCode>()
         aBookingItem.ticketCodes.forEach {
-            aTicketCode ->
-            val thePersonCategory = getPersonCategory(aTicketCode.personCategoryIndex)
+            //aTicketCode ->
+            val thePersonCategory = getPersonCategory(it.personCategoryIndex)
             val ticketData = ticketMetadata[thePersonCategory]
             if(ticketData != null && ticketData.ticketsCreated < ticketData.totalTickets) {
                 Ticket.new {
-                    code = aTicketCode.code
+                    code = it.code
                     bookingItem = targetBookingItem
                     basePrice = ticketData.ticketPrice
                     personCategory = thePersonCategory
                 }
                 ticketData.ticketsCreated++
-            } else if(ticketData != null //there were extra ticket codes
-                    && !erroredPersonCategories.contains(thePersonCategory)) {
+            } else if(ticketData != null ) {
+                // There were extra ticket codes
                 AdvanceSyncError.new {
                     errorType = SyncErrorType.extraTicketCodes
                     booking = targetBookingItem.booking
-                    message = "Advance ticket code ${aTicketCode.code} was skipped because pricing " +
+                    message = "Advance ticket code ${it.code} was skipped because pricing " +
                             "data only listed ${ticketData.totalTickets} tickets"
                 }
-                erroredPersonCategories.add(thePersonCategory)
-            } else if(!erroredPersonCategories.contains(thePersonCategory)){
+                recycledTicketCodes.add(it)
+            } else {
+                // There were no references to this Person Category in pricing
                 AdvanceSyncError.new {
                     errorType = SyncErrorType.mismatchTicketCodes
                     booking = targetBookingItem.booking
-                    message = "Advance ticket code ${aTicketCode.code} was skipped because pricing " +
+                    message = "Advance ticket code ${it.code} was skipped because pricing " +
                             "data didn't list any ${thePersonCategory.name} tickets"
                 }
+                recycledTicketCodes.add(it)
             }
         }
-        createMissingTickets(targetBookingItem, ticketMetadata)
+        createMissingTickets(targetBookingItem, ticketMetadata, recycledTicketCodes)
+        recycledTicketCodes.forEach {
+            AdvanceSyncError.new {
+                errorType = SyncErrorType.unusableTicketCode
+                booking = targetBookingItem.booking
+                message = "Skipped ${getPersonCategory(it.personCategoryIndex)} ticket ${it.code} entirely."
+            }
+        }
     }
 
     private fun generatePersonCategoryTicketData(
-            aBookingItem: AdvanceBookingItem
+            aBookingItem: AdvanceBookingItem,
+            targetBookingItem: BookingItem
     ) : Map<PersonCategory, PersonCategoryTicketData> {
         val result = mutableMapOf<PersonCategory, PersonCategoryTicketData>()
         aBookingItem.lineTotals.filter { it.type == 1101 }.forEach {
-            lineTotal ->
             val personCategory = PersonCategory.find {
-                (PersonCategories.externalSource eq source) and (PersonCategories.name eq lineTotal.label)
-            }.first()
-            val ticketPrice = lineTotal.price.setScale(decimalScale).divide(
-                    BigDecimal(lineTotal.quantity).setScale(decimalScale),
+                (PersonCategories.externalSource eq source) and (PersonCategories.name eq it.label)
+            }.firstOrNull() ?: PersonCategory.new {
+                externalId = null
+                externalSource = source
+                name = it.label
+                description = ""
+            }
+            if(personCategory.externalId == null) {
+                //flushEntityCache()
+                AdvanceSyncError.new {
+                    errorType = SyncErrorType.missingPersonCategory
+                    booking = targetBookingItem.booking
+                    message = "Reference to missing Person Category ${personCategory.name}. TicketPile version has " +
+                            "TicketPile ID {${personCategory.id.value} and no description."
+                }
+            }
+            
+            val ticketPrice = it.price.setScale(decimalScale).divide(
+                    BigDecimal(it.quantity).setScale(decimalScale),
                     RoundingMode.HALF_UP
             )
-            result[personCategory] = PersonCategoryTicketData(ticketPrice, lineTotal.quantity)
+            result[personCategory] = PersonCategoryTicketData(ticketPrice, it.quantity)
         }
         return result
     }
 
     private fun createMissingTickets(
             targetBookingItem: BookingItem,
-            ticketMetadata: Map<PersonCategory, PersonCategoryTicketData>
+            ticketMetadata: Map<PersonCategory, PersonCategoryTicketData>,
+            recycledTicketCodes : MutableList<AdvanceTicketCode>
     ) {
         ticketMetadata.forEach {
             val thePersonCategory = it.key
             val ticketData = it.value
-            var hasErrored = false
             while(ticketData.ticketsCreated < ticketData.totalTickets) {
-                if(!hasErrored) {
+                var code = "No Ticket Code Generated"
+                if(recycledTicketCodes.isEmpty()) {
                     AdvanceSyncError.new {
                         errorType = SyncErrorType.missingTicketCodes
                         booking = targetBookingItem.booking
                         message = "Created missing ticket code for ${thePersonCategory.name} ticket on Advance " +
                                 "booking item ${targetBookingItem.externalId}"
                     }
-                    hasErrored = true
+                } else {
+                    val ticketCode = recycledTicketCodes.removeAt(0)
+                    code = ticketCode.code
+                    AdvanceSyncError.new {
+                        errorType = SyncErrorType.missingTicketCodes
+                        booking = targetBookingItem.booking
+                        message = "Recycled skipped ${getPersonCategory(ticketCode.personCategoryIndex)} " +
+                                "ticket code $code as as a {${thePersonCategory.name} ticket instead."
+                    }
                 }
                 Ticket.new {
-                    code = "No Ticket Code Generated"
+                    this.code = code
                     bookingItem = targetBookingItem
                     basePrice = ticketData.ticketPrice
                     personCategory = thePersonCategory

--- a/src/main/kotlin/ticketpile/service/advance/AdvanceBookingManager.kt
+++ b/src/main/kotlin/ticketpile/service/advance/AdvanceBookingManager.kt
@@ -34,7 +34,7 @@ class AdvanceBookingManager(host: String, authorizationKey: String, locationId: 
      */
     fun importByAdvanceReservation(reservation:AdvanceReservation) : Booking {
 
-        //Delete the booking if it already exists.
+        // Delete the booking if it already exists.
         Booking.find {
             (Bookings.externalSource eq source) and
                     (Bookings.externalId eq reservation.bookingID)
@@ -58,11 +58,11 @@ class AdvanceBookingManager(host: String, authorizationKey: String, locationId: 
         importFees(booking, reservation)
         flushEntityCache()
 
-        // Transformation
+        // Transformation of adjustments onto tickets
         TicketAdjustmentTransform.transform(booking)
         flushEntityCache()
 
-        // Validation
+        // Validation of import
         validateImportResult(booking, reservation)
         flushEntityCache()
         booking.matchesExternal = booking.errors.isEmpty()

--- a/src/main/kotlin/ticketpile/service/advance/AdvanceManager.kt
+++ b/src/main/kotlin/ticketpile/service/advance/AdvanceManager.kt
@@ -26,7 +26,7 @@ import java.sql.Connection
  * 
  * Created by jonlatane on 10/10/16.
  */
-abstract class AdvanceManager {
+open class AdvanceManager {
     companion object {
         internal val restTemplate = RestTemplate()
         internal val dateTimeFormatter = DateTimeFormat.forPattern(
@@ -224,9 +224,9 @@ abstract class AdvanceManager {
         return responseEntity.body
     }
 
-    val currentUser : AdvanceUser get() {
+    val currentUser : AdvanceUser? get() {
         return api20Request(
-                "/authorization/current-user",
+                "/authorize/current-user",
                 AdvanceUserRespose::class.java
         ).user
     }

--- a/src/main/kotlin/ticketpile/service/advance/AdvanceManager.kt
+++ b/src/main/kotlin/ticketpile/service/advance/AdvanceManager.kt
@@ -8,12 +8,8 @@ import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.web.client.RestTemplate
-import ticketpile.service.database.Customers
-import ticketpile.service.database.PersonCategories
-import ticketpile.service.database.Products
-import ticketpile.service.model.Customer
-import ticketpile.service.model.PersonCategory
-import ticketpile.service.model.Product
+import ticketpile.service.database.*
+import ticketpile.service.model.*
 import ticketpile.service.util.flushEntityCache
 import ticketpile.service.util.transaction
 import java.net.URI
@@ -94,6 +90,42 @@ open class AdvanceManager {
         }, isolationLevel = Connection.TRANSACTION_SERIALIZABLE, logging = false)
     }
 
+    /**
+     * Advance Booking Items are hard to get an availability from.  This encapsulates
+     * that.  Assumes [AdvanceLocationManager.importRelatedAvailabilities] has been
+     * called for Booking Items with valid availabilities.
+     */
+    internal fun findAvailabilityFor(bookingItem : AdvanceBookingItem) : Event {
+        if(bookingItem.availabilityID != 0) {
+            return Event.find {
+                (Events.externalSource eq source) and
+                        (Events.externalId eq bookingItem.availabilityID)
+            }.first()
+        } else {
+            val product = getProduct(bookingItem.productID)
+            var event = Event.find {
+                (Events.externalSource eq source) and
+                        (Events.externalId eq null as Int?) and
+                        (Events.startTime eq bookingItem.startDateTime) and
+                        (Events.endTime eq bookingItem.endDateTime) and
+                        (Events.product eq product.id) and
+                        (Events.locationId eq locationId)
+            }.firstOrNull()
+            if(event == null) {
+                event = Event.new {
+                    externalId = null
+                    externalSource = source
+                    startTime = bookingItem.startDateTime
+                    endTime = bookingItem.endDateTime
+                    capacity = -1
+                    this.product = product
+                    locationId = this@AdvanceManager.locationId
+                }
+            }
+            return event
+        }
+    }
+
     fun importPersonCategories() {
         val personCategoryResponse = api20Request(
                 "/personcategories?merchantID=$locationId",
@@ -117,7 +149,7 @@ open class AdvanceManager {
     
     fun importProducts() {
         val productsResponse = api20Request(
-                "/merchants/$locationId/products?merchantID=$locationId",
+                "/merchants/$locationId/products?includeDeleted=true&merchantID=$locationId",
                 AdvanceProductsReponse::class.java)
         productsResponse.products.forEach {
             aProduct: AdvanceProduct ->
@@ -135,24 +167,32 @@ open class AdvanceManager {
             externalId = aProduct.productID
             externalSource = source
             name = aProduct.name
-            description = aProduct.shortDescription
+            description = aProduct.shortDescription ?: ""
         }
         product.name = aProduct.name
-        product.description = aProduct.shortDescription
+        product.description = aProduct.shortDescription ?: ""
     }
 
     internal fun getProduct(productId : Int) : Product {
-        val result = Product.find {
+        var result = Product.find {
             (Products.externalSource eq source) and
                     (Products.externalId eq productId)
         }.firstOrNull()
-        if(result == null) {
+        if(result == null) { // First check for new products.
             importProducts()
             flushEntityCache()
-            return Product.find {
+            result = Product.find {
                 (Products.externalSource eq source) and
                         (Products.externalId eq productId)
-            }.first()
+            }.firstOrNull() 
+        }
+        if(result == null) { // Advance's lack of FKs means a product has been lost completely.
+            result = Product.new { 
+                externalSource = source
+                externalId = productId
+                name = "Unreferenced Product"
+                description = "A Product that is missing from Advance entirely."
+            }
         }
         return result
     }
@@ -182,6 +222,23 @@ open class AdvanceManager {
      */
     internal fun getExternalPersonCategoryId(personCategoryIndex : Int) : Int {
         return (10 * locationId) + personCategoryIndex
+    }
+    
+    internal fun getDiscountName(label : String) : String {
+        return label.removePrefix("Discount:").trim()
+    }
+    
+    internal fun getDiscount(advanceDiscount : AdvancePriceAdjustment) : Discount {
+        if(advanceDiscount.promotionID != null) {
+            return Discount.find {
+                (Discounts.externalSource eq source) and
+                        (Discounts.externalId eq advanceDiscount.promotionID)
+            }.first()
+        }
+        return Discount.find {
+            (Discounts.externalSource eq source) and
+                    (Discounts.name eq getDiscountName(advanceDiscount.label))
+        }.first()
     }
 
     internal fun importCustomer(advanceCustomer : AdvanceCustomer) : Customer {

--- a/src/main/kotlin/ticketpile/service/advance/Validation.kt
+++ b/src/main/kotlin/ticketpile/service/advance/Validation.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import org.jetbrains.exposed.dao.EntityID
 import ticketpile.service.database.Bookings
 import ticketpile.service.model.Booking
+import ticketpile.service.util.BigZero
 import ticketpile.service.util.ReferenceTable
 import ticketpile.service.util.RelationalEntity
 import ticketpile.service.util.RelationalEntityClass
@@ -81,8 +82,7 @@ fun validateImportResult(booking : Booking, reservation : AdvanceReservation) {
     //Test booking total of confirmed bookings.  Bookings that should calculate as negative are expected
     //to calculate as zero from Advance. See booking 3418678/A-1BHNMT from The Ride.
     if(reservation.bookingStatus == "confirmed"
-        && booking.bookingTotal >= BigDecimal.ZERO
-        && (booking.bookingTotal - reservation.pricing.totalAmount).abs() > BigDecimal(0.00001)
+        && (booking.bookingTotal!! - reservation.pricing.totalAmount).abs() > BigDecimal(0.00001)
     )
         AdvanceSyncError.new {
             errorType = SyncErrorType.bookingTotal

--- a/src/main/kotlin/ticketpile/service/advance/Validation.kt
+++ b/src/main/kotlin/ticketpile/service/advance/Validation.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import org.jetbrains.exposed.dao.EntityID
 import ticketpile.service.database.Bookings
 import ticketpile.service.model.Booking
-import ticketpile.service.util.BigZero
 import ticketpile.service.util.ReferenceTable
 import ticketpile.service.util.RelationalEntity
 import ticketpile.service.util.RelationalEntityClass
@@ -28,7 +27,10 @@ enum class SyncErrorType(val description : String, val level: SyncErrorLevel) {
     extraTicketCodes("Advance generated an extra ticket code", SyncErrorLevel.warning),
     mismatchTicketCodes("Advance had ticket codes for a person category not listing in pricing", SyncErrorLevel.warning),
     extraDiscountCodes("Advance listed the same discount on a booking twice", SyncErrorLevel.warning),
-    inApplicableAdjustment("A discount or add-on was listed that shouldn't apply to any tickets", SyncErrorLevel.warning);
+    inApplicableAdjustment("A discount or add-on was listed that shouldn't apply to any tickets", SyncErrorLevel.warning),
+    missingPersonCategory("A Person Category was listed in pricing information that is not listed in Merchant's Person Categories", SyncErrorLevel.warning),
+    unusableTicketCode("A Ticket Code couldn't be allocated to any pricing data and didn't survive the import to TicketPile", SyncErrorLevel.warning);
+
     companion object {
         val errors : List<SyncErrorType> by lazy {
             SyncErrorType.values().filter { it.level == SyncErrorLevel.error }
@@ -82,12 +84,12 @@ fun validateImportResult(booking : Booking, reservation : AdvanceReservation) {
     //Test booking total of confirmed bookings.  Bookings that should calculate as negative are expected
     //to calculate as zero from Advance. See booking 3418678/A-1BHNMT from The Ride.
     if(reservation.bookingStatus == "confirmed"
-        && (booking.bookingTotal!! - reservation.pricing.totalAmount).abs() > BigDecimal(0.00001)
+        && (booking.totalAmount!! + booking.taxAmount - reservation.pricing.totalAmount).abs() > BigDecimal(0.00001)
     )
         AdvanceSyncError.new {
             errorType = SyncErrorType.bookingTotal
             this.booking = booking
-            message = "TicketPile: $${booking.bookingTotal}; " +
+            message = "TicketPile: $${booking.totalAmount}; " +
                     "Advance: $${reservation.pricing.totalAmount}"
         }
 }

--- a/src/main/kotlin/ticketpile/service/controllers/AdjustmentController.kt
+++ b/src/main/kotlin/ticketpile/service/controllers/AdjustmentController.kt
@@ -4,6 +4,7 @@ import org.jetbrains.exposed.dao.EntityClass
 import org.jetbrains.exposed.dao.IntEntity
 import ticketpile.service.model.*
 import ticketpile.service.util.BadRequestException
+import ticketpile.service.util.BigZero
 import ticketpile.service.util.ResourceNotFoundException
 import ticketpile.service.util.transaction
 import java.math.BigDecimal
@@ -23,7 +24,7 @@ abstract class AdjustmentController<SubjectType: IntEntity> (
     ): AdjustmentType
             where AdjustmentType : DiscountAdjustment<SubjectType>,
             AdjustmentClass : EntityClass<Int, AdjustmentType> {
-        if(discountAmount > BigDecimal.ZERO) 
+        if(discountAmount > BigZero) 
             throw BadRequestException("Amount is too high!")
         var subjectAdjustment : AdjustmentType? = null
 

--- a/src/main/kotlin/ticketpile/service/database/AdjustmentTable.kt
+++ b/src/main/kotlin/ticketpile/service/database/AdjustmentTable.kt
@@ -2,7 +2,6 @@ package ticketpile.service.database
 
 import ticketpile.service.util.ReferenceTable
 import ticketpile.service.util.RelationalTable
-import ticketpile.service.util.decimalScale
 
 /**
  * The base ways we can affect the price of Tickets, Events
@@ -11,7 +10,7 @@ import ticketpile.service.util.decimalScale
  */
 
 open class AdjustmentTable(singularName: String, subject : RelationalTable) : ReferenceTable(singularName, subject) {
-    val amount = decimal("amount", precision = 65, scale = decimalScale)
+    val amount = decimal("amount")
 }
 
 open class DiscountTable(singularName: String, subject : RelationalTable) : AdjustmentTable(singularName, subject) {

--- a/src/main/kotlin/ticketpile/service/database/Schema.kt
+++ b/src/main/kotlin/ticketpile/service/database/Schema.kt
@@ -2,6 +2,7 @@ package ticketpile.service.database
 
 import ticketpile.service.model.AddOnBasis
 import ticketpile.service.model.DiscountBasis
+import ticketpile.service.util.BigZero
 import ticketpile.service.util.ReferenceTable
 import ticketpile.service.util.RelationalTable
 
@@ -18,6 +19,7 @@ object Bookings : RelationalTable("booking") {
     val customer = reference(Customers).index()
     val matchesExternal = bool("matchesExternal").default(false).index()
     val locationId = integer("location")
+    val taxAmount = decimal("taxAmount").default(BigZero)
     
     //Caching columns
     val basePrice = decimal("basePrice").nullable()
@@ -26,12 +28,11 @@ object Bookings : RelationalTable("booking") {
     val addOnsAmount = decimal("addOnsAmount").nullable()
     val manualAdjustmentsAmount = decimal("manualAdjustmentsAmount").nullable()
     val itemAddOnsAmount = decimal("itemAddOnsAmount").nullable()
-    val grossAmount = decimal("grossAmount").nullable()
-    
-    val bookingTotal = decimal("bookingTotal").nullable()
+    val grossAmount = decimal("grossAmount").nullable() //Sum of the above
+    val totalAmount = decimal("totalAmount").nullable() //
 
     /**
-     * @see [ticketpile.service.graphql.BookingQuery.bookingOp]
+     * @see [ticketpile.service.graphql.BookingSearch.bookingOp]
      */
     val idxGraphQL = index(false, locationId, externalId, status, code)
 }
@@ -56,6 +57,8 @@ object BookingItems : RelationalTable("bookingItem") {
     val manualAdjustmentsAmount = decimal("manualAdjustmentsAmount").nullable()
     val itemAddOnsAmount = decimal("itemAddOnsAmount").nullable()
     val grossAmount = decimal("grossAmount").nullable()
+    
+    val totalAmount = decimal("totalAmount").nullable()
 }
 
 object Tickets : ReferenceTable("ticket", BookingItems) {
@@ -63,14 +66,16 @@ object Tickets : ReferenceTable("ticket", BookingItems) {
     val basePrice = decimal("baseprice")
     val code = varchar("code", length = 128)
     
-    //Caching columns
+    // Caching columns
     val discountsAmount = decimal("discountsAmount").nullable()
     val feesAmount = decimal("feesAmount").nullable()
     val addOnsAmount = decimal("addOnsAmount").nullable()
     val manualAdjustmentsAmount = decimal("manualAdjustmentsAmount").nullable()
     val itemAddOnsAmount = decimal("itemAddOnsAmount").nullable()
     val grossAmount = decimal("grossAmount").nullable()
+    val totalAmount = decimal("totalAmount").nullable()
     
+    // More caching columns useful for analysis
     val discountCount = integer("discountCount").nullable()
     val feeCount = integer("feeCount").nullable()
     val addOnCount = integer("addOnCount").nullable()

--- a/src/main/kotlin/ticketpile/service/database/Schema.kt
+++ b/src/main/kotlin/ticketpile/service/database/Schema.kt
@@ -19,6 +19,17 @@ object Bookings : RelationalTable("booking") {
     val matchesExternal = bool("matchesExternal").default(false).index()
     val locationId = integer("location")
     
+    //Caching columns
+    val basePrice = decimal("basePrice").nullable()
+    val discountsAmount = decimal("discountsAmount").nullable()
+    val feesAmount = decimal("feesAmount").nullable()
+    val addOnsAmount = decimal("addOnsAmount").nullable()
+    val manualAdjustmentsAmount = decimal("manualAdjustmentsAmount").nullable()
+    val itemAddOnsAmount = decimal("itemAddOnsAmount").nullable()
+    val grossAmount = decimal("grossAmount").nullable()
+    
+    val bookingTotal = decimal("bookingTotal").nullable()
+    
     val idxGraphQL = index(false, externalId, status, code)
 }
 
@@ -33,6 +44,15 @@ object Events : RelationalTable("event") {
 object BookingItems : RelationalTable("bookingItem") {
     val event = reference("event", Events)
     val booking = reference("booking", Bookings)
+
+    //Caching columns
+    val basePrice = decimal("basePrice").nullable()
+    val discountsAmount = decimal("discountsAmount").nullable()
+    val feesAmount = decimal("feesAmount").nullable()
+    val addOnsAmount = decimal("addOnsAmount").nullable()
+    val manualAdjustmentsAmount = decimal("manualAdjustmentsAmount").nullable()
+    val itemAddOnsAmount = decimal("itemAddOnsAmount").nullable()
+    val grossAmount = decimal("grossAmount").nullable()
 }
 
 object Tickets : ReferenceTable("ticket", BookingItems) {
@@ -47,6 +67,12 @@ object Tickets : ReferenceTable("ticket", BookingItems) {
     val manualAdjustmentsAmount = decimal("manualAdjustmentsAmount").nullable()
     val itemAddOnsAmount = decimal("itemAddOnsAmount").nullable()
     val grossAmount = decimal("grossAmount").nullable()
+    
+    val discountCount = integer("discountCount").nullable()
+    val feeCount = integer("feeCount").nullable()
+    val addOnCount = integer("addOnCount").nullable()
+    val manualAdjustmentCount = integer("manualAdjustmentCount").nullable()
+    val itemAddOnCount = integer("itemAddOnCount").nullable()
 }
 
 // Other things tracked by ID

--- a/src/main/kotlin/ticketpile/service/database/Schema.kt
+++ b/src/main/kotlin/ticketpile/service/database/Schema.kt
@@ -37,8 +37,16 @@ object BookingItems : RelationalTable("bookingItem") {
 
 object Tickets : ReferenceTable("ticket", BookingItems) {
     val personCategory = reference(PersonCategories)
-    val basePrice = decimal("baseprice", precision = 65, scale = 30)
+    val basePrice = decimal("baseprice")
     val code = varchar("code", length = 128)
+    
+    //Caching columns
+    val discountsAmount = decimal("discountsAmount").nullable()
+    val feesAmount = decimal("feesAmount").nullable()
+    val addOnsAmount = decimal("addOnsAmount").nullable()
+    val manualAdjustmentsAmount = decimal("manualAdjustmentsAmount").nullable()
+    val itemAddOnsAmount = decimal("itemAddOnsAmount").nullable()
+    val grossAmount = decimal("grossAmount").nullable()
 }
 
 // Other things tracked by ID

--- a/src/main/kotlin/ticketpile/service/database/Schema.kt
+++ b/src/main/kotlin/ticketpile/service/database/Schema.kt
@@ -29,8 +29,11 @@ object Bookings : RelationalTable("booking") {
     val grossAmount = decimal("grossAmount").nullable()
     
     val bookingTotal = decimal("bookingTotal").nullable()
-    
-    val idxGraphQL = index(false, externalId, status, code)
+
+    /**
+     * @see [ticketpile.service.graphql.BookingQuery.bookingOp]
+     */
+    val idxGraphQL = index(false, locationId, externalId, status, code)
 }
 
 object Events : RelationalTable("event") {

--- a/src/main/kotlin/ticketpile/service/graphql/BookingQuery.kt
+++ b/src/main/kotlin/ticketpile/service/graphql/BookingQuery.kt
@@ -7,6 +7,8 @@ import ticketpile.service.database.BookingItems
 import ticketpile.service.database.Bookings
 import ticketpile.service.database.Events
 import ticketpile.service.model.Booking
+import ticketpile.service.util.BigZero
+import java.math.BigDecimal
 
 /**
  * Encapsulation of a query for [Booking]s.
@@ -74,12 +76,18 @@ internal class BookingQuery(
     val totalCount by lazy {
         result.count()
     }
-    val totalGross by lazy {
-        result.map{it.bookingTotal}.reduce{ amount1, amount2 -> amount1 + amount2 }
+    val totalGross : BigDecimal by lazy {
+        result.map{it.bookingTotal!!}.fold(
+                initial = BigZero,
+                operation = {
+                    amount1, amount2 -> amount1 + amount2
+                })
     }
-    val pageGross by lazy {
-        results.map(Booking::bookingTotal).reduce { 
+    val pageGross : BigDecimal by lazy {
+        results.map{it.bookingTotal!!}.fold(
+                initial = BigZero,
+                operation = { 
             amount1, amount2 -> amount1 + amount2 
-        }
+        })
     }
 }

--- a/src/main/kotlin/ticketpile/service/graphql/BookingSearch.kt
+++ b/src/main/kotlin/ticketpile/service/graphql/BookingSearch.kt
@@ -6,6 +6,8 @@ import ticketpile.service.database.BookingItems
 import ticketpile.service.database.Bookings
 import ticketpile.service.database.Events
 import ticketpile.service.model.Booking
+import ticketpile.service.model.Ticket
+import ticketpile.service.model.transformation.Weighable
 import ticketpile.service.util.BigZero
 import java.math.BigDecimal
 
@@ -16,7 +18,8 @@ import java.math.BigDecimal
  */
 val minDate = DateTime("1000-01-01T00:00:00")
 val maxDate = DateTime("9999-12-31T00:00:00")
-class BookingQuery(
+
+class BookingSearch (
         /**
          * When no locations are provided, will search *no* locations.
          */
@@ -28,22 +31,26 @@ class BookingQuery(
         var id : Int?,
         var limit : Int,
         var offset : Int
-) {
+) : Weighable {
     private val eventBookingIds : Set<Int>? by lazy {
+        // If Event date ranges were used, precompute
+        // the valid bookings. This may be optimized later,
+        // if necessary.
         if(eventsAfter != null || eventsBefore != null) {
-            val result = setOf(*(Events innerJoin BookingItems innerJoin Bookings)
-                    .slice(Events.id, BookingItems.event, BookingItems.booking, Bookings.id, Bookings.externalId)
-                    .select {
-                        Events.locationId inList locations and
-                                (if (eventsAfter != null)
-                                    Events.startTime greaterEq eventsAfter!!
-                                else
-                                    Events.startTime greaterEq minDate) and
-                                (if (eventsBefore != null)
-                                    Events.startTime lessEq eventsBefore!!
-                                else
-                                    Events.startTime lessEq maxDate)
-                    }.map {
+        val result = setOf(
+                *(Events innerJoin BookingItems innerJoin Bookings)
+                .slice(Events.id, BookingItems.event, BookingItems.booking, Bookings.id, Bookings.externalId)
+                .select {
+                    Events.locationId inList locations and
+                    (if (eventsAfter != null)
+                        Events.startTime greaterEq eventsAfter!!
+                    else
+                        Events.startTime greaterEq minDate) and
+                    (if (eventsBefore != null)
+                        Events.startTime lessEq eventsBefore!!
+                    else
+                        Events.startTime lessEq maxDate)
+                }.map {
                 it[Bookings.externalId]!!
             }.toTypedArray())
             if(id != null) {
@@ -82,33 +89,35 @@ class BookingQuery(
                 .select(bookingOp)
                 .first()[column.sum()]!!
     }
-    val totalAmount: BigDecimal by lazy {
-        total(Bookings.bookingTotal)
+    override val totalAmount: BigDecimal by lazy {
+        total(Bookings.totalAmount)
     }
-    val basePrice: BigDecimal by lazy {
+    override val basePrice: BigDecimal by lazy {
         total(Bookings.basePrice)
     }
-    val discountsAmount: BigDecimal by lazy {
+    override val discountsAmount: BigDecimal by lazy {
         total(Bookings.discountsAmount)
     }
-    val feesAmount: BigDecimal by lazy {
+    override val feesAmount: BigDecimal by lazy {
         total(Bookings.feesAmount)
     }
-    val addOnsAmount: BigDecimal by lazy {
+    override val addOnsAmount: BigDecimal by lazy {
         total(Bookings.addOnsAmount)
     }
-    val manualAdjustmentsAmount: BigDecimal by lazy {
+    override val manualAdjustmentsAmount: BigDecimal by lazy {
         total(Bookings.manualAdjustmentsAmount)
     }
-    val itemAddOnsAmount: BigDecimal by lazy {
+    override val itemAddOnsAmount: BigDecimal by lazy {
         total(Bookings.itemAddOnsAmount)
     }
-    val grossAmount: BigDecimal by lazy {
+    override val grossAmount: BigDecimal by lazy {
         total(Bookings.grossAmount)
     }
+    override val tickets: List<Ticket>
+        get() = throw UnsupportedOperationException()
     
     val pageTotal: BigDecimal by lazy {
-        results.map { it.bookingTotal!! }.fold(
+        results.map { it.totalAmount!! }.fold(
                 initial = BigZero,
                 operation = {
                     amount1, amount2 ->

--- a/src/main/kotlin/ticketpile/service/graphql/GraphQLAdjustments.kt
+++ b/src/main/kotlin/ticketpile/service/graphql/GraphQLAdjustments.kt
@@ -1,0 +1,98 @@
+package ticketpile.service.graphql
+
+import graphql.Scalars
+import graphql.schema.GraphQLFieldDefinition
+import graphql.schema.GraphQLObjectType
+import ticketpile.service.model.AddOnAdjustment
+import ticketpile.service.model.DiscountAdjustment
+import ticketpile.service.model.FeeAdjustment
+import ticketpile.service.model.ManualAdjustment
+
+/**
+ * Mappings for [Adjustment] types to [GraphQLObjectType]s
+ * 
+ * Created by jonlatane on 10/15/16.
+ */
+val discountAdjustment: GraphQLObjectType =
+        GraphQLObjectType.newObject().name("DiscountAdjustment")
+                .field(GraphQLFieldDefinition.newFieldDefinition().type(Scalars.GraphQLInt)
+                        .name("promotionId")
+                        .dataFetcher {
+                            (it.source as DiscountAdjustment<*>).discount.externalId!!
+                        }
+                        .build())
+                .field(GraphQLFieldDefinition.newFieldDefinition().type(Scalars.GraphQLString)
+                        .name("code")
+                        .dataFetcher {
+                            (it.source as DiscountAdjustment<*>).discount.name
+                        }
+                        .build())
+                .field(GraphQLFieldDefinition.newFieldDefinition().type(Scalars.GraphQLString)
+                        .name("description")
+                        .dataFetcher {
+                            (it.source as DiscountAdjustment<*>).discount.description
+                        }
+                        .build())
+                .field(GraphQLFieldDefinition.newFieldDefinition().type(GraphQLBigDecimal)
+                        .name("amount")
+                        .dataFetcher {
+                            (it.source as DiscountAdjustment<*>).amount
+                        }
+                        .build())
+                .build()
+
+
+
+val addOnAdjustment: GraphQLObjectType =
+        GraphQLObjectType.newObject().name("AddOnAdjustment")
+                .field(GraphQLFieldDefinition.newFieldDefinition().type(Scalars.GraphQLString)
+                        .name("name")
+                        .dataFetcher {
+                            (it.source as AddOnAdjustment<*>).addOn.name
+                        }
+                        .build())
+                .field(GraphQLFieldDefinition.newFieldDefinition().type(Scalars.GraphQLString)
+                        .name("selection")
+                        .dataFetcher {
+                            (it.source as AddOnAdjustment<*>).selection
+                        }
+                        .build())
+                .field(GraphQLFieldDefinition.newFieldDefinition().type(GraphQLBigDecimal)
+                        .name("amount")
+                        .dataFetcher {
+                            (it.source as AddOnAdjustment<*>).amount
+                        }
+                        .build())
+                .build()
+
+val manualAdjustment: GraphQLObjectType =
+        GraphQLObjectType.newObject().name("ManualAdjustment")
+                .field(GraphQLFieldDefinition.newFieldDefinition().type(Scalars.GraphQLString)
+                        .name("description")
+                        .dataFetcher {
+                            (it.source as ManualAdjustment<*>).description
+                        }
+                        .build())
+                .field(GraphQLFieldDefinition.newFieldDefinition().type(GraphQLBigDecimal)
+                        .name("amount")
+                        .dataFetcher {
+                            (it.source as ManualAdjustment<*>).amount
+                        }
+                        .build())
+                .build()
+
+val feeAdjustment : GraphQLObjectType =
+        GraphQLObjectType.newObject().name("FeeAdjustment")
+                .field(GraphQLFieldDefinition.newFieldDefinition().type(Scalars.GraphQLString)
+                        .name("description")
+                        .dataFetcher {
+                            (it.source as FeeAdjustment<*>).description
+                        }
+                        .build())
+                .field(GraphQLFieldDefinition.newFieldDefinition().type(GraphQLBigDecimal)
+                        .name("amount")
+                        .dataFetcher {
+                            (it.source as FeeAdjustment<*>).amount
+                        }
+                        .build())
+                .build()

--- a/src/main/kotlin/ticketpile/service/graphql/GraphQLBigDecimal.kt
+++ b/src/main/kotlin/ticketpile/service/graphql/GraphQLBigDecimal.kt
@@ -1,0 +1,37 @@
+package ticketpile.service.graphql
+
+import graphql.language.FloatValue
+import graphql.schema.Coercing
+import graphql.schema.GraphQLScalarType
+import java.math.BigDecimal
+
+/**
+ * IEEE 754 (i.e. Float/Double) is a PITA.  For instance, create a Float with value 87.55.
+ * Now print it: 87.55000305175781. Lollerskates.  [GraphQLFloat] is unsuitable for real financial
+ * work. [GraphQLBigDecimal] solves this problem.
+ * 
+ * Created by jonlatane on 10/14/16.
+ */
+val GraphQLBigDecimal = GraphQLScalarType("BigDecimal", "Java BigDecimal", object : Coercing {
+    override fun serialize(input: Any): BigDecimal? {
+        if (input is String) {
+            return BigDecimal(input)
+        } else if (input is BigDecimal) {
+            return input
+        } else if (input is Float) {
+            return BigDecimal(input.toDouble())
+        } else if (input is Int) {
+            return BigDecimal(input)
+        } else {
+            return null
+        }
+    }
+
+    override fun parseValue(input: Any): BigDecimal? {
+        return serialize(input)
+    }
+
+    override fun parseLiteral(input: Any): Any {
+        return BigDecimal((input as FloatValue).value.toDouble())
+    }
+})

--- a/src/main/kotlin/ticketpile/service/graphql/GraphQLController.kt
+++ b/src/main/kotlin/ticketpile/service/graphql/GraphQLController.kt
@@ -2,23 +2,30 @@ package ticketpile.service.graphql
 
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.*
+import ticketpile.service.springconfig.BearerToken
+import ticketpile.service.util.AuthenticationException
 import ticketpile.service.util.transaction
 import javax.servlet.http.HttpServletRequest
 
 /**
+ * Basic GraphQL controller for TicketPile.
+ * 
  * Created by jonlatane on 10/11/16.
  */
 @RestController
 @RequestMapping(value = "/graphql")
 open class TPGraphQLController {
-    @PostMapping(produces = arrayOf(MediaType.APPLICATION_JSON_VALUE))
+    @GetMapping(produces = arrayOf(MediaType.APPLICATION_JSON_VALUE))
     @ResponseBody
     fun executeOperation(@RequestBody body : Map<String, Any>): Any {
+        val auth = SecurityContextHolder.getContext().authentication as BearerToken
+        val graphQL = createGraphQL(auth.user!!)
         val query = body["query"] as String
         val variables = body["variables"] as Map<String, Any>?
         val executionResult = transaction {
-            TicketPileGraphQL.execute(query, null as Any?, variables)
+            graphQL.execute(query, null as Any?, variables)
         }
         val result = mutableMapOf<String, Any>()
         if (executionResult.errors?.count() ?: 0 > 0) {
@@ -36,6 +43,11 @@ open class TPGraphQLController {
     fun postJson(@RequestBody body: Map<String, Any>,
                  @RequestHeader(value = "graphql-schema", required = false) graphQLSchemaName: String?,
                  httpServletRequest: HttpServletRequest): ResponseEntity<Map<String, Any>> {
+        val auth = SecurityContextHolder.getContext().authentication as BearerToken
+        if(auth.user == null) {
+            throw AuthenticationException("User must be logged in to access GraphQL.")
+        }
+        val graphQL = createGraphQL(auth.user)
 
         val query = body["query"] as String
         //val operationName = body["operationName"] as String?
@@ -45,7 +57,7 @@ open class TPGraphQLController {
         } catch(t:Throwable) {}
 
         val executionResult = transaction {
-            TicketPileGraphQL.execute(query, null as Any?, variables)
+            graphQL.execute(query, null as Any?, variables)
         }
         val result : Map<String, Any>
         if (executionResult.errors?.count() ?: 0 > 0) {

--- a/src/main/kotlin/ticketpile/service/graphql/GraphQLController.kt
+++ b/src/main/kotlin/ticketpile/service/graphql/GraphQLController.kt
@@ -50,14 +50,14 @@ open class TPGraphQLController {
         val graphQL = createGraphQL(auth.user)
 
         val query = body["query"] as String
-        //val operationName = body["operationName"] as String?
+        val operationName = body["operationName"] as String?
         var variables = emptyMap<String, Any>()
         try {
            variables = body["variables"] as Map<String, Any>
         } catch(t:Throwable) {}
 
         val executionResult = transaction {
-            graphQL.execute(query, null as Any?, variables)
+            graphQL.execute(query, operationName, null as Any?, variables)
         }
         val result : Map<String, Any>
         if (executionResult.errors?.count() ?: 0 > 0) {

--- a/src/main/kotlin/ticketpile/service/graphql/GraphQLController.kt
+++ b/src/main/kotlin/ticketpile/service/graphql/GraphQLController.kt
@@ -43,9 +43,25 @@ open class TPGraphQLController {
         try {
            variables = body["variables"] as Map<String, Any>
         } catch(t:Throwable) {}
-        val result = transaction {
+
+        val executionResult = transaction {
+            TicketPileGraphQL.execute(query, null as Any?, variables)
+        }
+        val result : Map<String, Any>
+        if (executionResult.errors?.count() ?: 0 > 0) {
+            result = mutableMapOf<String, Any>()
+            result.put("errors", executionResult.errors.map{
+                "${it.javaClass.simpleName}: ${it.locations}"
+            })
+            println("Errors: {${executionResult.errors}}")
+        } else {
+            result = executionResult.data as Map<String,Any>
+        }
+        
+        
+        /*val result = transaction {
             TicketPileGraphQL.execute(query, null as Any?, variables).data
-        } as Map<String, Any>
+        } as Map<String, Any>*/
 
         return ResponseEntity.ok<Map<String, Any>>(result)
     }

--- a/src/main/kotlin/ticketpile/service/graphql/GraphQLSchema.kt
+++ b/src/main/kotlin/ticketpile/service/graphql/GraphQLSchema.kt
@@ -49,7 +49,7 @@ val TicketPileGraphQLSchema : GraphQLSchema by lazy {
                         code = it.arguments["code"] as String?,
                         id = it.arguments["id"] as Int?,
                         status = it.arguments["status"] as String?,
-                        limit = Math.max(it.arguments["limit"] as Int, 100),
+                        limit = Math.min(it.arguments["limit"] as Int, 200),
                         offset = it.arguments["offset"] as Int
                     )
             }.build())

--- a/src/main/kotlin/ticketpile/service/graphql/GraphQLSchema.kt
+++ b/src/main/kotlin/ticketpile/service/graphql/GraphQLSchema.kt
@@ -65,18 +65,21 @@ val TicketPileGraphQLSchema : GraphQLSchema by lazy {
             }.build())
         .field(newFieldDefinition().type(GraphQLFloat)
             .name("pageGross")
+            .description("The total gross for bookings on this page (defined by limit and offset)")
             .dataFetcher {
                (it.source as BookingQuery).pageGross.toFloat()
             }
             .build())
-        //.field(newFieldDefinition().type(GraphQLFloat)
-            //.name("totalGross")
-            //.dataFetcher {
-            //    (it.source as BookingQuery).totalGross
-            //}
-            //.build())
+        .field(newFieldDefinition().type(GraphQLFloat)
+            .name("totalGross")
+            .description("The total gross for all bookings found in this search")
+            .dataFetcher {
+                (it.source as BookingQuery).totalGross.toFloat()
+            }
+            .build())
         .field(newFieldDefinition().type(GraphQLList(GraphQLTypeReference("Booking")))
             .name("results")
+            .description("A list of bookings that matched the query")
             .dataFetcher {
                 (it.source as BookingQuery).results
             }
@@ -99,6 +102,7 @@ val TicketPileGraphQLSchema : GraphQLSchema by lazy {
         newObject().name("Booking")
             .field(newFieldDefinition().type(GraphQLInt)
                 .name("id")
+                .description("The Advance Booking ID for this booking")
                 .dataFetcher {
                     (it.source as Booking).externalId!!
                 }

--- a/src/main/kotlin/ticketpile/service/graphql/GraphQLSchema.kt
+++ b/src/main/kotlin/ticketpile/service/graphql/GraphQLSchema.kt
@@ -118,7 +118,7 @@ val TicketPileGraphQLSchema : GraphQLSchema by lazy {
             .field(newFieldDefinition().type(GraphQLFloat)
                 .name("totalGross")
                 .dataFetcher {
-                    (it.source as Booking).bookingTotal.toFloat()
+                    (it.source as Booking).bookingTotal!!.toFloat()
                 }
                 .build())
             .field(newFieldDefinition().type(GraphQLList(GraphQLTypeReference("BookingItem")))
@@ -275,7 +275,7 @@ val TicketPileGraphQLSchema : GraphQLSchema by lazy {
         .field(newFieldDefinition().type(GraphQLFloat)
             .name("totalGross")
             .dataFetcher {
-                (it.source as Ticket).grossRevenue.toFloat()
+                (it.source as Ticket).grossAmount!!.toFloat()
             }
             .build())
         .build()

--- a/src/main/kotlin/ticketpile/service/graphql/WeighableBuilder.kt
+++ b/src/main/kotlin/ticketpile/service/graphql/WeighableBuilder.kt
@@ -1,0 +1,73 @@
+package ticketpile.service.graphql
+
+import graphql.schema.GraphQLFieldDefinition.newFieldDefinition
+import graphql.schema.GraphQLObjectType
+import ticketpile.service.model.transformation.Weighable
+
+/**
+ * A handy dandy shortcut 
+ * Created by jonlatane on 10/14/16.
+ */
+fun GraphQLObjectType.Builder.weighableFields(
+        itemType : String = "Object"
+) : GraphQLObjectType.Builder {
+    return this
+        .field(newFieldDefinition().type(GraphQLBigDecimal)
+            .name("basePrice")
+            .description("The base price of this $itemType, before discounts, addons, etc.")
+            .dataFetcher {
+                (it.source as Weighable).basePrice!!
+            }
+            .build())
+        .field(newFieldDefinition().type(GraphQLBigDecimal)
+            .name("discountsAmount")
+            .description("The total value of all Discounts on this $itemType.")
+            .dataFetcher {
+                (it.source as Weighable).discountsAmount!!
+            }
+            .build())
+        .field(newFieldDefinition().type(GraphQLBigDecimal)
+            .name("feesAmount")
+            .description("The total value of all Fees on this $itemType.")
+            .dataFetcher {
+                (it.source as Weighable).feesAmount!!
+            }
+            .build())
+        .field(newFieldDefinition().type(GraphQLBigDecimal)
+            .name("addOnsAmount")
+            .description("The total value of all AddOns on this $itemType.")
+            .dataFetcher {
+                (it.source as Weighable).addOnsAmount!!
+            }
+            .build())
+        .field(newFieldDefinition().type(GraphQLBigDecimal)
+            .name("manualAdjustmentsAmount")
+            .description("The total value of all ManualAdjustments on this $itemType.")
+            .dataFetcher {
+                (it.source as Weighable).manualAdjustmentsAmount!!
+            }
+            .build())
+        .field(newFieldDefinition().type(GraphQLBigDecimal)
+            .name("itemAddOnsAmount")
+            .description("The total value of all AddOns on this $itemType.")
+            .dataFetcher {
+                (it.source as Weighable).itemAddOnsAmount!!
+            }
+            .build())
+        .field(newFieldDefinition().type(GraphQLBigDecimal)
+            .name("grossAmount")
+            .description("The gross value of this $itemType.  May potentially be negative.  Calculated as: " +
+                    "basePrice + discountsAmount + feesAmount + addOnsAmount + manualAdjustmentsAmount + itemAddOnsAmount")
+            .dataFetcher {
+                (it.source as Weighable).grossAmount!!
+            }
+            .build())
+        .field(newFieldDefinition().type(GraphQLBigDecimal)
+            .name("totalAmount")
+            .description("The total value of this $itemType, which is never negative. " +
+                    "Calculated as max(grossAmount, 0).")
+            .dataFetcher {
+                (it.source as Weighable).totalAmount!!
+            }
+            .build())
+}

--- a/src/main/kotlin/ticketpile/service/model/AddOn.kt
+++ b/src/main/kotlin/ticketpile/service/model/AddOn.kt
@@ -4,23 +4,15 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import org.jetbrains.exposed.dao.EntityID
 import org.jetbrains.exposed.dao.IntEntityClass
 import ticketpile.service.database.AddOns
+import ticketpile.service.model.basis.pricePerItem
+import ticketpile.service.model.basis.pricePerPerson
+import ticketpile.service.model.transformation.Weighable
+import ticketpile.service.model.basis.weighByApplicableGrossRevenue
+import ticketpile.service.model.basis.weighByApplicableTicketCount
 import ticketpile.service.util.PrimaryEntity
 import ticketpile.service.util.decimalScale
 import java.math.BigDecimal
 
-/**
- * Created by jonlatane on 10/7/16.
- */
-val pricePerItem = {
-    amount: BigDecimal, weighable: Weighable ->
-    amount
-}
-val pricePerPerson = {
-    amount: BigDecimal, weighable: Weighable ->
-    val result = (amount.setScale(decimalScale)) *
-            (BigDecimal(weighable.tickets.count()))
-    result
-}
 enum class AddOnBasis(
         val weightMethod : (BigDecimal, Weighable, Ticket, (Ticket) -> Boolean) -> BigDecimal,
         val priceMethod : (BigDecimal, Weighable) -> BigDecimal

--- a/src/main/kotlin/ticketpile/service/model/Adjustments.kt
+++ b/src/main/kotlin/ticketpile/service/model/Adjustments.kt
@@ -1,6 +1,8 @@
 package ticketpile.service.model
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import ticketpile.service.util.BigZero
+import ticketpile.service.util.decimalScale
 import java.math.BigDecimal
 
 
@@ -19,6 +21,15 @@ import java.math.BigDecimal
  * 
  * Created by jonlatane on 8/28/16.
  */
+fun adjustmentTotal(adjustments : List<Adjustment<*>>) : BigDecimal {
+    return adjustments.map{it.amount}.fold(
+            initial = BigZero,
+            operation = {
+                amount1, amount2 ->
+                amount1 + amount2
+            }
+    )
+}
 
 interface Adjustment<SubjectType : Weighable> {
     var subject : SubjectType

--- a/src/main/kotlin/ticketpile/service/model/Adjustments.kt
+++ b/src/main/kotlin/ticketpile/service/model/Adjustments.kt
@@ -1,15 +1,15 @@
 package ticketpile.service.model
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import ticketpile.service.model.transformation.Weighable
 import ticketpile.service.util.BigZero
-import ticketpile.service.util.decimalScale
 import java.math.BigDecimal
 
 
 /**
  * All the adjustments that can be accrued on stuff.
  * 
- * Right now Advance only supports:
+ * Right now Advance supports:
  * 
  * - [DiscountAdjustment] on [Booking]: [BookingDiscount]
  * - [AddOnAdjustment] on [Booking]: [BookingAddOn]
@@ -17,11 +17,21 @@ import java.math.BigDecimal
  * - [FeeAdjustment] on [Booking]: [BookingFee]
  * - [AddOnAdjustment] on [BookingItem]: [BookingItemAddOn]
  * 
- * A [MappedAdjustment] should always implement one of the above interfaces and
+ * TicketPile maps data to [Ticket]s.  The mappings of the above are as follows, respectively:
+ *
+ * - [DiscountAdjustment] on [Booking]: [TicketBookingDiscount]
+ * - [AddOnAdjustment] on [Booking]: [TicketBookingAddOn]
+ * - [ManualAdjustment] on [Booking]: [TicketBookingManualAdjustment]
+ * - [FeeAdjustment] on [Booking]: [TicketBookingFee]
+ * - [AddOnAdjustment] on [BookingItem]: [TicketBookingItemAddOn]
  * 
  * Created by jonlatane on 8/28/16.
  */
-fun adjustmentTotal(adjustments : List<Adjustment<*>>) : BigDecimal {
+
+/**
+ * Calculate the total value of several adjustments.
+ */
+fun adjustmentTotal(adjustments : Iterable<Adjustment<*>>) : BigDecimal {
     return adjustments.map{it.amount}.fold(
             initial = BigZero,
             operation = {

--- a/src/main/kotlin/ticketpile/service/model/Booking.kt
+++ b/src/main/kotlin/ticketpile/service/model/Booking.kt
@@ -86,28 +86,28 @@ class Booking(id: EntityID<Int>) : PrimaryEntity(id, Bookings), Weighable {
     @get:JsonProperty
     var discountsAmount by cacheNotifierColumn(
             column = Bookings.discountsAmount,
-            calculation = { itemTotal({it.discountsAmount!!}) },
+            calculation = { adjustmentTotal(discounts) },
             notifier = {
                 this.grossAmount = null
             })
     @get:JsonProperty
     var feesAmount by cacheNotifierColumn(
             column = Bookings.feesAmount,
-            calculation = { itemTotal({it.feesAmount!!}) },
+            calculation = { adjustmentTotal(fees) },
             notifier = {
                 this.grossAmount = null
             })
     @get:JsonProperty
     var addOnsAmount by cacheNotifierColumn(
             column = Bookings.addOnsAmount,
-            calculation = { itemTotal({it.addOnsAmount!!}) },
+            calculation = { adjustmentTotal(addOns) },
             notifier = {
                 this.grossAmount = null
             })
     @get:JsonProperty
     var manualAdjustmentsAmount by cacheNotifierColumn(
             column = Bookings.manualAdjustmentsAmount,
-            calculation = { itemTotal({it.manualAdjustmentsAmount!!}) },
+            calculation = { adjustmentTotal(manualAdjustments) },
             notifier = {
                 this.grossAmount = null
             })

--- a/src/main/kotlin/ticketpile/service/model/Booking.kt
+++ b/src/main/kotlin/ticketpile/service/model/Booking.kt
@@ -136,8 +136,8 @@ class Booking(id: EntityID<Int>) : PrimaryEntity(id, Bookings), Weighable {
             })
     
     fun populateCaches() {
-        bookingTotal!!
         items.forEach(BookingItem::populateCaches)
+        bookingTotal!!
     }
     
     private fun itemTotal(operator: (BookingItem) -> BigDecimal) : BigDecimal {

--- a/src/main/kotlin/ticketpile/service/model/BookingItem.kt
+++ b/src/main/kotlin/ticketpile/service/model/BookingItem.kt
@@ -79,7 +79,7 @@ class BookingItem(id: EntityID<Int>) : PrimaryEntity(id, BookingItems), Weighabl
     @get:JsonProperty
     var itemAddOnsAmount : BigDecimal? by cacheNotifierColumn(
             column = BookingItems.itemAddOnsAmount,
-            calculation = { ticketTotal({it.itemAddOnsAmount!!}) },
+            calculation = { adjustmentTotal(addOns) },
             notifier = {
                 this.grossAmount = null
                 this.booking.itemAddOnsAmount = null

--- a/src/main/kotlin/ticketpile/service/model/BookingItem.kt
+++ b/src/main/kotlin/ticketpile/service/model/BookingItem.kt
@@ -97,8 +97,8 @@ class BookingItem(id: EntityID<Int>) : PrimaryEntity(id, BookingItems), Weighabl
             })
 
     fun populateCaches() {
-        grossAmount!!
         tickets.forEach(Ticket::populateCaches)
+        grossAmount!!
     }
     
     override fun delete() {

--- a/src/main/kotlin/ticketpile/service/model/Discount.kt
+++ b/src/main/kotlin/ticketpile/service/model/Discount.kt
@@ -6,8 +6,12 @@ import org.jetbrains.exposed.dao.IntEntityClass
 import ticketpile.service.database.DiscountPersonCategories
 import ticketpile.service.database.DiscountProducts
 import ticketpile.service.database.Discounts
+import ticketpile.service.model.basis.weighByApplicableGrossRevenue
+import ticketpile.service.model.basis.weighByApplicableTicketCount
+import ticketpile.service.model.transformation.Weighable
 import ticketpile.service.util.PrimaryEntity
 import ticketpile.service.util.RelationalEntity
+import ticketpile.service.util.RelationalEntityClass
 import java.math.BigDecimal
 
 /**
@@ -29,8 +33,8 @@ class Discount(id: EntityID<Int>) : PrimaryEntity(id, Discounts) {
     @get:JsonProperty
     var basis: DiscountBasis by Discounts.basis
 
-    private val _products by DiscountProduct referrersOn DiscountProducts.parent
-    private val _personCategories by DiscountPersonCategory referrersOn DiscountPersonCategories.parent
+    private val _products by DiscountProduct childrenOn DiscountProducts.parent
+    private val _personCategories by DiscountPersonCategory childrenOn DiscountPersonCategories.parent
     val products: Iterable<Product> get() {
         val result = mutableListOf<Product>()
         _products.forEach { result.add(it.product) }
@@ -55,7 +59,7 @@ enum class DiscountBasis(val weightMethod : (BigDecimal, Weighable, Ticket, (Tic
  * Fundamental component of discount applicability along with [DiscountProduct].
  */
 class DiscountPersonCategory(id: EntityID<Int>) : RelationalEntity(id) {
-    companion object : IntEntityClass<DiscountPersonCategory>(DiscountPersonCategories)
+    companion object : RelationalEntityClass<DiscountPersonCategory>(DiscountPersonCategories)
     var discount by Discount referencedOn DiscountPersonCategories.parent
     var personCategory by PersonCategory referencedOn DiscountPersonCategories.personCategory
 }
@@ -64,7 +68,7 @@ class DiscountPersonCategory(id: EntityID<Int>) : RelationalEntity(id) {
  * Fundamental component of discount applicability along with [DiscountPersonCategory].
  */
 class DiscountProduct(id: EntityID<Int>) : RelationalEntity(id) {
-    companion object : IntEntityClass<DiscountProduct>(DiscountProducts)
+    companion object : RelationalEntityClass<DiscountProduct>(DiscountProducts)
     var discount by Discount referencedOn DiscountProducts.parent
     var product by Product referencedOn DiscountProducts.product
 }

--- a/src/main/kotlin/ticketpile/service/model/Ticket.kt
+++ b/src/main/kotlin/ticketpile/service/model/Ticket.kt
@@ -35,6 +35,31 @@ class Ticket(id: EntityID<Int>) : PrimaryEntity(id, Tickets), Weighable {
     val bookingDiscountAdjustments by TicketBookingDiscount childrenOn TicketBookingDiscounts.parent
     val bookingItemAddOnAdjustments by TicketBookingItemAddOn childrenOn TicketBookingItemAddOns.parent
     
+    var discountsAmount by cacheColumn(Tickets.discountsAmount, {
+        bookingDiscountAdjustments.map{it.amount}
+                .reduce { amount1, amount2 -> amount1 + amount2 }
+    })
+    var feesAmount by cacheColumn(Tickets.feesAmount, {
+        bookingFeeAdjustments.map{it.amount}
+                .reduce { amount1, amount2 -> amount1 + amount2 }
+    })
+    var addOnsAmount by cacheColumn(Tickets.addOnsAmount, {
+        bookingAddOnAdjustments.map{it.amount}
+                .reduce { amount1, amount2 -> amount1 + amount2 }
+    })
+    var manualAdjustmentsAmount by cacheColumn(Tickets.manualAdjustmentsAmount, {
+        bookingManualAdjustments.map{it.amount}
+                .reduce { amount1, amount2 -> amount1 + amount2 }
+    })
+    var itemAddOnsAmount by cacheColumn(Tickets.itemAddOnsAmount, {
+        bookingItemAddOnAdjustments.map{it.amount}
+                .reduce { amount1, amount2 -> amount1 + amount2 }
+    })
+    var grossAmount by cacheColumn(Tickets.grossAmount, {
+        basePrice + discountsAmount!! + feesAmount!! + addOnsAmount!! +
+                manualAdjustmentsAmount!! + itemAddOnsAmount!!
+    })
+    
     @get:JsonProperty
     override val grossRevenue : BigDecimal get() {
         var result = basePrice

--- a/src/main/kotlin/ticketpile/service/model/Ticket.kt
+++ b/src/main/kotlin/ticketpile/service/model/Ticket.kt
@@ -29,66 +29,118 @@ class Ticket(id: EntityID<Int>) : PrimaryEntity(id, Tickets), Weighable {
     @get:JsonProperty
     var basePrice by Tickets.basePrice
     
-    val bookingAddOnAdjustments by TicketBookingAddOn childrenOn TicketBookingAddOns.parent
-    val bookingManualAdjustments by TicketBookingManualAdjustment childrenOn TicketBookingManualAdjustments.parent
-    val bookingFeeAdjustments by TicketBookingFee childrenOn TicketBookingFees.parent
-    val bookingDiscountAdjustments by TicketBookingDiscount childrenOn TicketBookingDiscounts.parent
-    val bookingItemAddOnAdjustments by TicketBookingItemAddOn childrenOn TicketBookingItemAddOns.parent
-    
-    var discountsAmount by cacheColumn(Tickets.discountsAmount, {
-        bookingDiscountAdjustments.map{it.amount}
-                .reduce { amount1, amount2 -> amount1 + amount2 }
-    })
-    var feesAmount by cacheColumn(Tickets.feesAmount, {
-        bookingFeeAdjustments.map{it.amount}
-                .reduce { amount1, amount2 -> amount1 + amount2 }
-    })
-    var addOnsAmount by cacheColumn(Tickets.addOnsAmount, {
-        bookingAddOnAdjustments.map{it.amount}
-                .reduce { amount1, amount2 -> amount1 + amount2 }
-    })
-    var manualAdjustmentsAmount by cacheColumn(Tickets.manualAdjustmentsAmount, {
-        bookingManualAdjustments.map{it.amount}
-                .reduce { amount1, amount2 -> amount1 + amount2 }
-    })
-    var itemAddOnsAmount by cacheColumn(Tickets.itemAddOnsAmount, {
-        bookingItemAddOnAdjustments.map{it.amount}
-                .reduce { amount1, amount2 -> amount1 + amount2 }
-    })
-    var grossAmount by cacheColumn(Tickets.grossAmount, {
-        basePrice + discountsAmount!! + feesAmount!! + addOnsAmount!! +
-                manualAdjustmentsAmount!! + itemAddOnsAmount!!
-    })
-    
+    val addOns by TicketBookingAddOn childrenOn TicketBookingAddOns.parent
+    val manualAdjustments by TicketBookingManualAdjustment childrenOn TicketBookingManualAdjustments.parent
+    val fees by TicketBookingFee childrenOn TicketBookingFees.parent
+    val discounts by TicketBookingDiscount childrenOn TicketBookingDiscounts.parent
+    val itemAddOns by TicketBookingItemAddOn childrenOn TicketBookingItemAddOns.parent
+
     @get:JsonProperty
-    override val grossRevenue : BigDecimal get() {
-        var result = basePrice
-        for(adjustments in listOf<List<Adjustment<*>>>(
-                bookingAddOnAdjustments,
-                bookingManualAdjustments,
-                bookingDiscountAdjustments,
-                bookingFeeAdjustments,
-                bookingItemAddOnAdjustments
-        )) {
-            for(adjustment in adjustments) {
-                result += adjustment.amount
-            }
-        }
-        return result
-    }
+    var discountsAmount by cacheNotifierColumn(
+            column = Tickets.discountsAmount,
+            calculation = { adjustmentTotal(discounts) },
+            notifier = {
+                this.grossAmount = null
+                this.bookingItem.discountsAmount = null
+            })
+    @get:JsonProperty
+    var feesAmount by cacheNotifierColumn(
+            column = Tickets.feesAmount,
+            calculation = { adjustmentTotal(fees) },
+            notifier = {
+                this.grossAmount = null
+                this.bookingItem.feesAmount = null
+            })
+    @get:JsonProperty
+    var addOnsAmount by cacheNotifierColumn(
+            column = Tickets.addOnsAmount,
+            calculation = { adjustmentTotal(addOns) },
+            notifier = {
+                this.grossAmount = null
+                this.bookingItem.addOnsAmount = null
+            })
+    @get:JsonProperty
+    var manualAdjustmentsAmount by cacheNotifierColumn(
+            column = Tickets.manualAdjustmentsAmount,
+            calculation = { adjustmentTotal(manualAdjustments) },
+            notifier = {
+                this.grossAmount = null
+                this.bookingItem.manualAdjustmentsAmount = null
+            })
+    @get:JsonProperty
+    var itemAddOnsAmount by cacheNotifierColumn(
+            column = Tickets.itemAddOnsAmount,
+            calculation = { adjustmentTotal(itemAddOns) },
+            notifier = {
+                this.grossAmount = null
+                this.bookingItem.itemAddOnsAmount = null
+            })
+    @get:JsonProperty
+    override var grossAmount : BigDecimal? by cacheNotifierColumn(
+            column = Tickets.grossAmount,
+            calculation = {
+                basePrice + discountsAmount!! + feesAmount!! + addOnsAmount!! +
+                        manualAdjustmentsAmount!! + itemAddOnsAmount!!
+            },
+            notifier = {
+                this.bookingItem.grossAmount = null
+            })
     @get:JsonProperty
     val discountedPrice : BigDecimal get() {
-        var result = basePrice
-        for(adjustment in bookingDiscountAdjustments) {
-            result += adjustment.amount
-        }
-        return result
+        return basePrice + discountsAmount!!
     }
+    
+    @get:JsonProperty
+    var discountCount by cacheColumn(
+            column = Tickets.discountCount,
+            calculation = {
+                discounts.count()
+            }
+    )
+    @get:JsonProperty
+    var feeCount by cacheColumn(
+            column = Tickets.feeCount,
+            calculation = {
+                fees.count()
+            }
+    )
+    @get:JsonProperty
+    var addOnCount by cacheColumn(
+            column = Tickets.addOnCount,
+            calculation = {
+                addOns.count()
+            }
+    )
+    @get:JsonProperty
+    var manualAdjustmentCount by cacheColumn(
+            column = Tickets.manualAdjustmentCount,
+            calculation = {
+                manualAdjustments.count()
+            }
+    )
+    @get:JsonProperty
+    var itemAddOnCount by cacheColumn(
+            column = Tickets.itemAddOnCount,
+            calculation = {
+                itemAddOns.count()
+            }
+    )
 
     override val tickets: List<Ticket>
         get() {
             return listOf(this)
         }
+
+    fun populateCaches() {
+        grossAmount!!
+        
+        discountCount!!
+        feeCount!!
+        addOnCount!!
+        manualAdjustmentCount!!
+        itemAddOnCount!!
+    }
+    
     override fun delete() {
         TicketBookingAddOns.deleteWhere {
             TicketBookingAddOns.parent eq id
@@ -127,7 +179,12 @@ class TicketBookingAddOn(id: EntityID<Int>) : RelationalEntity(id), AddOnAdjustm
     @get:JsonProperty
     override var addOn by AddOn referencedOn TicketBookingAddOns.addon
     @get:JsonProperty
-    override var amount by TicketBookingAddOns.amount
+    override var amount : BigDecimal by notifierColumn(
+            column = TicketBookingAddOns.amount,
+            notifier = {
+                this.subject.addOnsAmount = null
+                this.subject.addOnCount = null
+            })
     @get:JsonProperty
     override var selection by TicketBookingAddOns.selection
     //@get:JsonProperty
@@ -141,7 +198,12 @@ class TicketBookingDiscount(id: EntityID<Int>) : RelationalEntity(id), DiscountA
     @get:JsonProperty
     override var discount by Discount referencedOn TicketBookingDiscounts.discount
     @get:JsonProperty
-    override var amount by TicketBookingDiscounts.amount
+    override var amount : BigDecimal by notifierColumn(
+            column = TicketBookingDiscounts.amount,
+            notifier = {
+                this.subject.discountsAmount = null
+                this.subject.discountCount = null
+            })
     //@get:JsonProperty
     override var sourceAdjustment by BookingDiscount referencedOn TicketBookingDiscounts.bookingDiscount
 }
@@ -153,7 +215,12 @@ class TicketBookingManualAdjustment(id: EntityID<Int>) : RelationalEntity(id), M
     @get:JsonProperty
     override var description by TicketBookingManualAdjustments.description
     @get:JsonProperty
-    override var amount by TicketBookingManualAdjustments.amount
+    override var amount : BigDecimal by notifierColumn(
+            column = TicketBookingManualAdjustments.amount,
+            notifier = {
+                this.subject.manualAdjustmentsAmount = null
+                this.subject.manualAdjustmentCount = null
+            })
     //@get:JsonProperty
     override var sourceAdjustment by BookingManualAdjustment referencedOn TicketBookingManualAdjustments.bookingManualAdjustment
 }
@@ -165,7 +232,12 @@ class TicketBookingFee(id: EntityID<Int>) : RelationalEntity(id), FeeAdjustment<
     @get:JsonProperty
     override var description by TicketBookingFees.description
     @get:JsonProperty
-    override var amount by TicketBookingFees.amount
+    override var amount : BigDecimal by notifierColumn(
+            column = TicketBookingFees.amount,
+            notifier = {
+                this.subject.feesAmount = null
+                this.subject.feeCount = null
+            })
     //@get:JsonProperty
     override var sourceAdjustment by BookingFee referencedOn TicketBookingFees.bookingFee
 }
@@ -177,7 +249,12 @@ class TicketBookingItemAddOn(id: EntityID<Int>) : RelationalEntity(id), AddOnAdj
     @get:JsonProperty
     override var addOn by AddOn referencedOn TicketBookingItemAddOns.addon
     @get:JsonProperty
-    override var amount by TicketBookingItemAddOns.amount
+    override var amount : BigDecimal by notifierColumn(
+            column = TicketBookingItemAddOns.amount,
+            notifier = {
+                this.subject.itemAddOnsAmount = null
+                this.subject.itemAddOnCount = null
+            })
     @get:JsonProperty
     override var selection by TicketBookingItemAddOns.selection
     //@get:JsonProperty

--- a/src/main/kotlin/ticketpile/service/model/basis/PriceBasis.kt
+++ b/src/main/kotlin/ticketpile/service/model/basis/PriceBasis.kt
@@ -1,0 +1,22 @@
+package ticketpile.service.model.basis
+
+import ticketpile.service.model.transformation.Weighable
+import ticketpile.service.util.decimalScale
+import java.math.BigDecimal
+
+/**
+ * Methods for applying AddOns to bookings as they are found from
+ * Advance.
+ * 
+ * Created by jonlatane on 10/7/16.
+ */
+val pricePerItem = {
+    amount: BigDecimal, weighable: Weighable ->
+    amount
+}
+val pricePerPerson = {
+    amount: BigDecimal, weighable: Weighable ->
+    val result = (amount.setScale(decimalScale)) *
+            (BigDecimal(weighable.tickets.count()))
+    result
+}

--- a/src/main/kotlin/ticketpile/service/model/basis/WeightBasis.kt
+++ b/src/main/kotlin/ticketpile/service/model/basis/WeightBasis.kt
@@ -1,0 +1,57 @@
+package ticketpile.service.model.basis
+
+import ticketpile.service.model.Ticket
+import ticketpile.service.model.transformation.Weighable
+import ticketpile.service.util.BigZero
+import ticketpile.service.util.decimalScale
+import java.math.BigDecimal
+
+/**
+ * Created by jonlatane on 10/15/16.
+ */
+val weighByApplicableTicketCount = {
+    amount : BigDecimal, weighable: Weighable, ticket: Ticket, applicable: (Ticket) -> Boolean ->
+    val applicableTickets = applicableTickets(weighable, applicable)
+    if(isReallyApplicable(ticket, weighable, applicable))
+        amount.setScale(decimalScale) / BigDecimal(applicableTickets.count()).setScale(decimalScale)
+    else
+        BigZero
+}
+val weighByApplicableGrossRevenue = {
+    amount : BigDecimal, weighable: Weighable, ticket: Ticket, applicable: (Ticket) -> Boolean ->
+    val applicableTickets = applicableTickets(weighable, applicable)
+    if(isReallyApplicable(ticket, weighable, applicable)) {
+        val applicableGross = applicableTickets.map { it.grossAmount }.fold(
+                initial = BigZero,
+                operation = {
+                    amount1, amount2 ->
+                    amount1!! + amount2!!
+                })
+        if(applicableGross == BigZero)
+            weighByApplicableTicketCount(amount, weighable, ticket, applicable)
+        else 
+            amount.setScale(decimalScale) *
+                    ticket.grossAmount!!.setScale(decimalScale) /
+                    applicableGross.setScale(decimalScale)
+    } else
+        BigZero
+}
+
+/**
+ * Returns true if the {@param ticket} is applicable or if no tickets in the {@param weighable} are applicable.
+ */
+private fun isReallyApplicable(ticket: Ticket, weighable: Weighable, applicable: (Ticket) -> Boolean) : Boolean {
+    return applicable(ticket) || weighable.tickets.filter(applicable).isEmpty()
+}
+
+/**
+ * Returns a list of all applicable tickets in the weighable, or a list of all tickets in the weighable if no
+ * tickets are applicable.
+ */
+private fun applicableTickets(weighable: Weighable, applicable: (Ticket) -> Boolean) : List<Ticket> {
+    var result= weighable.tickets.filter(applicable)
+    if(result.isEmpty()) {
+        result = weighable.tickets
+    }
+    return result
+}

--- a/src/main/kotlin/ticketpile/service/model/transformation/Weighable.kt
+++ b/src/main/kotlin/ticketpile/service/model/transformation/Weighable.kt
@@ -1,0 +1,23 @@
+package ticketpile.service.model.transformation
+
+import ticketpile.service.model.Ticket
+import java.math.BigDecimal
+
+/**
+ * Basis of, like, everything.  By implementing this interface, you 
+ * assert that none of the below fields will ever return null.
+ * 
+ * @see [RelationalEntity.cacheColumn]
+ * Created by jonlatane on 10/15/16.
+ */
+interface Weighable {
+    val tickets : List<Ticket>
+    val basePrice : BigDecimal?
+    val discountsAmount : BigDecimal?
+    val feesAmount : BigDecimal?
+    val addOnsAmount : BigDecimal?
+    val manualAdjustmentsAmount : BigDecimal?
+    val itemAddOnsAmount : BigDecimal?
+    val grossAmount : BigDecimal?
+    val totalAmount : BigDecimal?
+}

--- a/src/main/kotlin/ticketpile/service/security/AdvanceSSOUser.kt
+++ b/src/main/kotlin/ticketpile/service/security/AdvanceSSOUser.kt
@@ -1,0 +1,12 @@
+package ticketpile.service.security
+
+import ticketpile.service.advance.AdvanceUser
+
+/**
+ * Created by jonlatane on 10/14/16.
+ */
+class AdvanceSSOUser(user : AdvanceUser) : ApplicationUser {
+    override val administrator = false
+    override val locations = user.merchants.map{it.locationId}
+
+}

--- a/src/main/kotlin/ticketpile/service/security/ApplicationUser.kt
+++ b/src/main/kotlin/ticketpile/service/security/ApplicationUser.kt
@@ -1,0 +1,9 @@
+package ticketpile.service.security
+
+/**
+ * Created by jonlatane on 10/14/16.
+ */
+interface ApplicationUser {
+    val administrator : Boolean
+    val locations : List<Int>
+}

--- a/src/main/kotlin/ticketpile/service/springconfig/SecurityConfiguration.kt
+++ b/src/main/kotlin/ticketpile/service/springconfig/SecurityConfiguration.kt
@@ -98,7 +98,7 @@ internal object provider : AuthenticationProvider {
         val user = (authentication as BearerToken).user
         if(user != null)
             return authentication
-        return null
+        return authentication
     }
 }
 

--- a/src/main/kotlin/ticketpile/service/util/RelationalEntity.kt
+++ b/src/main/kotlin/ticketpile/service/util/RelationalEntity.kt
@@ -69,7 +69,7 @@ abstract class RelationalEntity(id: EntityID<Int>) : IntEntity(id) {
     }
 
     fun <T> cacheNotifierColumn(column : Column<T?>, calculation : () -> T, notifier : () -> Unit) : WrappedColumn<T?> {
-        return WrappedColumn<T?>(
+        return WrappedColumn(
                 getter = {
                     o, desc ->
                     var result = column.getValue(o, desc)

--- a/src/main/kotlin/ticketpile/service/util/RelationalEntity.kt
+++ b/src/main/kotlin/ticketpile/service/util/RelationalEntity.kt
@@ -76,12 +76,13 @@ abstract class RelationalEntity(id: EntityID<Int>) : IntEntity(id) {
                     if(result == null) {
                         result = calculation()
                         column.setValue(o, desc, result)
+                        notifier()
                     }
                     result
                 },
                 setter = {
                     o, desc, value : T? ->
-                    column.setValue(o, desc, value)
+                    column.setValue(o, desc, null)
                     notifier()
                 }
         )

--- a/src/main/kotlin/ticketpile/service/util/RelationalTable.kt
+++ b/src/main/kotlin/ticketpile/service/util/RelationalTable.kt
@@ -10,6 +10,8 @@ import java.math.BigDecimal
  */
 val decimalScale = 30
 val decimalPrecision = 65
+val BigZero = BigDecimal.ZERO.setScale(decimalScale)
+val BigOne = BigDecimal.ONE.setScale(decimalScale)
 
 open class RelationalTable(val singularName : String) : IntIdTable() {
     var externalSource = varchar(name="externalHost", length = 128).nullable().index()

--- a/src/main/kotlin/ticketpile/service/util/RelationalTable.kt
+++ b/src/main/kotlin/ticketpile/service/util/RelationalTable.kt
@@ -3,17 +3,22 @@ package ticketpile.service.util
 import org.jetbrains.exposed.dao.EntityID
 import org.jetbrains.exposed.dao.IntIdTable
 import org.jetbrains.exposed.sql.Column
+import java.math.BigDecimal
 
 /**
  * Created by jonlatane on 10/9/16.
  */
 val decimalScale = 30
+val decimalPrecision = 65
 
 open class RelationalTable(val singularName : String) : IntIdTable() {
     var externalSource = varchar(name="externalHost", length = 128).nullable().index()
     var externalId = integer("externalId").nullable().index()
     fun reference(foreign: RelationalTable) : Column<EntityID<Int>> {
         return reference(foreign.singularName, foreign)
+    }
+    fun decimal(name: String) : Column<BigDecimal> {
+        return decimal(name, precision = decimalPrecision, scale = decimalScale)
     }
 }
 

--- a/src/main/resources/static/graphiql.html
+++ b/src/main/resources/static/graphiql.html
@@ -20,13 +20,13 @@
     <script src="/webjars/graphiql/0.6.6/graphiql.min.js"></script>
 </head>
 <body>
-<div style="font-family: arial, sans-serif; font-size: 12px;" align="right">
-    Auth/Bearer Token:
+<div style="font-family: arial, sans-serif; font-size: 12px; background-color: #eeeeee;" align="right">
+    Authentication Token:
     <input 
             id=authTokenInput 
             style="width:250px;"
             type="text" 
-            placeholder="Advance OR TicketPile Auth Token"
+            placeholder="Advance OR TicketPile Bearer Token"
             onchange="onChangeAuthToken()"
     />
 </div>

--- a/src/main/resources/static/graphiql.html
+++ b/src/main/resources/static/graphiql.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body {
+            height: 100%;
+            margin: 0;
+            width: 100%;
+            overflow: hidden
+        }
+
+        #graphiql {
+            height: 100vh
+        }
+    </style>
+    <link rel=stylesheet href="/webjars/graphiql/0.6.6/graphiql.min.css"/>
+    <script src="/webjars/fetch/0.9.0/fetch.min.js"></script>
+    <script src="/webjars/react/0.14.7/react.min.js"></script>
+    <script src="/webjars/react/0.14.7/react-dom.min.js"></script>
+    <script src="/webjars/graphiql/0.6.6/graphiql.min.js"></script>
+</head>
+<body>
+<div style="font-family: arial, sans-serif; font-size: 12px;" align="right">
+    Auth/Bearer Token:
+    <input 
+            id=authTokenInput 
+            style="width:250px;"
+            type="text" 
+            placeholder="Advance OR TicketPile Auth Token"
+            onchange="onChangeAuthToken()"
+    />
+</div>
+<div id=graphiql>Loading...</div>
+<script>
+    var search = window.location.search;
+    var parameters = {};
+    search.substr(1).split("&").forEach(function(b) {
+        var a = b.indexOf("=");
+        if (a >= 0) {
+            parameters[decodeURIComponent(b.slice(0, a))] = decodeURIComponent(b.slice(a + 1))
+        }
+    });
+    if (parameters.variables) {
+        try {
+            parameters.variables = JSON.stringify(JSON.parse(parameters.variables), null , 2)
+        } catch (e) {}
+    }
+    var authToken = "";
+    function onChangeAuthToken() {
+        authToken = document.getElementById("authTokenInput").value
+    }
+    function onEditQuery(a) {
+        parameters.query = a;
+        updateURL()
+    }
+    function onEditVariables(a) {
+        parameters.variables = a;
+        updateURL()
+    }
+    function onEditOperationName(a) {
+        parameters.operationName = a;
+        updateURL()
+    }
+    function updateURL() {
+        var a = "?" + Object.keys(parameters).filter(function(b) {
+                    return Boolean(parameters[b])
+                }).map(function(b) {
+                    return encodeURIComponent(b) + "=" + encodeURIComponent(parameters[b])
+                }).join("&");
+        history.replaceState(null , null , a)
+    }
+    function graphQLFetcher(a) {
+        return fetch(window.location.origin + "/graphql", {
+            method: "post",
+            headers: {
+                Accept: "application/json",
+                "Content-Type": "application/json",
+                Bearer: authToken
+            },
+            body: JSON.stringify(a),
+            credentials: "include",
+        }).then(function(b) {
+            return b.text()
+        }).then(function(c) {
+            try {
+                return JSON.parse(c)
+            } catch (b) {
+                return c
+            }
+        })
+    }
+    ReactDOM.render(React.createElement(GraphiQL, {
+        fetcher: graphQLFetcher,
+        query: parameters.query,
+        variables: parameters.variables,
+        operationName: parameters.operationName,
+        onEditQuery: onEditQuery,
+        onEditVariables: onEditVariables,
+        onEditOperationName: onEditOperationName
+    }), document.getElementById("graphiql"));
+</script>
+</body>
+</html>


### PR DESCRIPTION
These changes make the GraphQL API stupid fast.  We can also now compensate for missing Products and Promotions in Advance, meaning we can successfully import advance-dev@zozi.com's data.  3/~1200 bookings still have mismatches in their booking total, pretty good for the merchant with some of the worst data!
